### PR TITLE
Remove logger and print to console

### DIFF
--- a/lib/elixircom.ex
+++ b/lib/elixircom.ex
@@ -1,5 +1,4 @@
 defmodule Elixircom do
-  require Logger
   alias Elixircom.Server
 
   @type uart_opts :: {:speed, non_neg_integer}
@@ -58,7 +57,7 @@ defmodule Elixircom do
   end
 
   defp log_error({:error, :enoent} = error) do
-    Logger.error("""
+    IO.puts("""
     Unable to find specified port.
 
     Please make sure your device is plugged in and ready to
@@ -69,7 +68,7 @@ defmodule Elixircom do
   end
 
   defp log_error({:error, :eagain} = error) do
-    Logger.error("""
+    IO.puts("""
     Serial port is already open.
 
     Make sure you are not connecting to the port in another
@@ -80,7 +79,7 @@ defmodule Elixircom do
   end
 
   defp log_error({:error, :eacces} = error) do
-    Logger.error("""
+    IO.puts("""
     Permission denied when opening port.
 
     Make sure you have the correct permissions to

--- a/lib/elixircom_server.ex
+++ b/lib/elixircom_server.ex
@@ -1,7 +1,6 @@
 defmodule Elixircom.Server do
   use GenServer
 
-  require Logger
   alias Nerves.UART
 
   defmodule State do
@@ -47,7 +46,7 @@ defmodule Elixircom.Server do
         {:nerves_uart, _name, {:error, :einval}},
         %State{group_leader: gl, io_restore_opts: io_opts} = state
       ) do
-    Logger.warn("""
+    IO.puts("""
     Looks like there is trouble with serial port communication, stopping Elixircom.
 
     Please ensure your device is connected.

--- a/mix.exs
+++ b/mix.exs
@@ -16,9 +16,7 @@ defmodule Elixircom.MixProject do
 
   # Run "mix help compile.app" to learn about applications.
   def application do
-    [
-      extra_applications: [:logger]
-    ]
+    []
   end
 
   # Run "mix help deps" to learn about dependencies.


### PR DESCRIPTION
This fixes lost error messages for when the Logger isn't actively being watched. The user is definitely watching stdout since this is an interactive utility. This prints the error messages out there.